### PR TITLE
To work on PHP 7.0 version of Homestead

### DIFF
--- a/pma.sh
+++ b/pma.sh
@@ -7,4 +7,4 @@ mkdir phpmyadmin && tar xf phpmyadmin.tar.gz -C phpmyadmin --strip-components 1
 
 rm phpmyadmin.tar.gz
 
-sudo bash /vagrant/scripts/serve.sh phpmyadmin.app $(pwd)/phpmyadmin
+sudo bash /vagrant/scripts/serve-hhvm.sh phpmyadmin.app $(pwd)/phpmyadmin


### PR DESCRIPTION
In PHP 7.0 version of Homestead there is no serve.sh only serve-hhvm.sh
