### PR TITLE
use .test TLD instead of .app, updated to phpmyadmin 4.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ on a Laravel Homestead box.
 
 3. `$ curl -sS https://raw.githubusercontent.com/grrnikos/pma/master/pma.sh | sh`
 
-4. Open the `/etc/hosts` file on your main machine and add `127.0.0.1  phpmyadmin.app`
+4. Open the `/etc/hosts` file on your main machine and add `127.0.0.1  phpmyadmin.test`
 
-5. Go to [http://phpmyadmin.app:8000](http://phpmyadmin.app:8000). Default credentials are username `homestead` and password `secret`
+5. Go to [http://phpmyadmin.test:8000](http://phpmyadmin.test:8000). Default credentials are username `homestead` and password `secret`
 
 ## License
 

--- a/pma.sh
+++ b/pma.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo 'Downloading phpMyAdmin 4.7.5'
-curl -#L https://files.phpmyadmin.net/phpMyAdmin/4.7.5/phpMyAdmin-4.7.5-english.tar.gz -o phpmyadmin.tar.gz
+echo 'Downloading phpMyAdmin 4.7.6'
+curl -#L https://files.phpmyadmin.net/phpMyAdmin/4.7.6/phpMyAdmin-4.7.6-english.tar.gz -o phpmyadmin.tar.gz
 
 mkdir phpmyadmin && tar xf phpmyadmin.tar.gz -C phpmyadmin --strip-components 1
 
@@ -15,9 +15,9 @@ if [ ! -f $CMD ]; then
     CMD=/vagrant/scripts/serve.sh
 else
     # Create an SSL certificate
-    sudo bash $CMD_CERT phpmyadmin.app
+    sudo bash $CMD_CERT phpmyadmin.test
 fi
 
-sudo bash $CMD phpmyadmin.app $(pwd)/phpmyadmin
+sudo bash $CMD phpmyadmin.test $(pwd)/phpmyadmin
 
 sudo service nginx reload


### PR DESCRIPTION
With the release of the Chrome 63, .app TLD can not be used as well as the .dev or .foo and the [others](https://www.registry.google/) as they will be forced to [redirect](https://twitter.com/ericlaw/status/937800787928977408). Details can be found [here](https://security.googleblog.com/2017/09/broadening-hsts-to-secure-more-of-web.html).