### PR TITLE
Fetch Latest Version and Assign Default PHP Version

### DIFF
--- a/pma.sh
+++ b/pma.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-echo 'Downloading phpMyAdmin 4.7.9'
-curl -#L https://files.phpmyadmin.net/phpMyAdmin/4.7.9/phpMyAdmin-4.7.9-english.tar.gz -o phpmyadmin.tar.gz
+LATEST_VERSION=$(curl -sS 'https://api.github.com/repos/phpmyadmin/phpmyadmin/releases/latest' | awk -F '"' '/tag_name/{print $4}')
+DOWNLOAD_URL="https://api.github.com/repos/phpmyadmin/phpmyadmin/tarball/$LATEST_VERSION"
+
+echo "Downloading phpMyAdmin $LATEST_VERSION"
+wget $DOWNLOAD_URL -q --show-progress -O 'phpmyadmin.tar.gz'
 
 mkdir phpmyadmin && tar xf phpmyadmin.tar.gz -C phpmyadmin --strip-components 1
 
@@ -18,6 +21,9 @@ else
     sudo bash $CMD_CERT phpmyadmin.test
 fi
 
-sudo bash $CMD phpmyadmin.test $(pwd)/phpmyadmin
+sudo bash $CMD phpmyadmin.test $(pwd)/phpmyadmin 80 443 7.3
+
+echo "Installing dependencies for phpMyAdmin"
+cd phpmyadmin && composer update --no-dev
 
 sudo service nginx reload


### PR DESCRIPTION
Greetings,

With this PR, from now on, the script will fetch the latest from Github, hence will serve the application with PHP 7.3 by default.