### PR TITLE
fix cookie error

### DIFF
--- a/pma.sh
+++ b/pma.sh
@@ -24,6 +24,6 @@ fi
 sudo bash $CMD phpmyadmin.test $(pwd)/phpmyadmin 80 443 7.3
 
 echo "Installing dependencies for phpMyAdmin"
-cd phpmyadmin && composer update --no-dev
+cd phpmyadmin && composer update --no-dev && yarn
 
 sudo service nginx reload


### PR DESCRIPTION
With the release of phpMyAdmin 5, one may get the error below.

> Failed to set session cookie. Maybe you are using HTTP instead of HTTPS to access phpMyAdmin.

Solution is running `yarn`.

 [Reference](https://github.com/phpmyadmin/phpmyadmin/issues/15200)